### PR TITLE
Hitorder

### DIFF
--- a/include/Event.hh
+++ b/include/Event.hh
@@ -78,7 +78,6 @@ private:
   Event_map<std::any> mymap; // defined at construction
   truth_t truthPack; // undefined at construction; bag with structure
   experiment_t expPack; // undefined at construction; fill structure
-  //  hit_t hitPack; // undefined at construction; fill structure
   std::vector<hit_t> hits; // for multiple hits per event
   
 public:
@@ -95,8 +94,6 @@ public:
   inline Event_map<std::any>& getRef() {return mymap;} // access
   inline truth_t& getTruthRef() {return truthPack;} // access
   inline experiment_t& getExperimentRef() {return expPack;} // access
-  //  inline hit_t& getHitRef() {return hitPack;} // access
-  //  inline hit_t getHit() {return hitPack;} // access
   inline std::vector<hit_t>& hitsRef() {return hits;} // access
 
 private:
@@ -113,14 +110,6 @@ private:
     truthPack.vertex.posz = 0.0 * m;
     truthPack.vertex.kineticenergy = 0.0 * eV;
     truthPack.vertex.pitchangle = 0.0 * deg;
-    // hitPack.locx = 0.0 * m;
-    // hitPack.locy = 0.0 * m;
-    // hitPack.locz = 0.0 * m;
-    // hitPack.timestamp = 0.0 * ns;
-    // hitPack.edeposit = 0.0 * eV;
-    // hitPack.kepre = 0.0 * eV;
-    // hitPack.kepost = 0.0 * eV;
-    // hitPack.anglepre = 0.0 * deg;
     expPack.target_frequency = 0.0 * Hz;
     expPack.digi_sampling_rate = 0.0 * Hz;
   }

--- a/include/Event.hh
+++ b/include/Event.hh
@@ -78,7 +78,7 @@ private:
   Event_map<std::any> mymap; // defined at construction
   truth_t truthPack; // undefined at construction; bag with structure
   experiment_t expPack; // undefined at construction; fill structure
-  hit_t hitPack; // undefined at construction; fill structure
+  //  hit_t hitPack; // undefined at construction; fill structure
   std::vector<hit_t> hits; // for multiple hits per event
   
 public:
@@ -95,8 +95,8 @@ public:
   inline Event_map<std::any>& getRef() {return mymap;} // access
   inline truth_t& getTruthRef() {return truthPack;} // access
   inline experiment_t& getExperimentRef() {return expPack;} // access
-  inline hit_t& getHitRef() {return hitPack;} // access
-  inline hit_t getHit() {return hitPack;} // access
+  //  inline hit_t& getHitRef() {return hitPack;} // access
+  //  inline hit_t getHit() {return hitPack;} // access
   inline std::vector<hit_t>& hitsRef() {return hits;} // access
 
 private:
@@ -113,14 +113,14 @@ private:
     truthPack.vertex.posz = 0.0 * m;
     truthPack.vertex.kineticenergy = 0.0 * eV;
     truthPack.vertex.pitchangle = 0.0 * deg;
-    hitPack.locx = 0.0 * m;
-    hitPack.locy = 0.0 * m;
-    hitPack.locz = 0.0 * m;
-    hitPack.timestamp = 0.0 * ns;
-    hitPack.edeposit = 0.0 * eV;
-    hitPack.kepre = 0.0 * eV;
-    hitPack.kepost = 0.0 * eV;
-    hitPack.anglepre = 0.0 * deg;
+    // hitPack.locx = 0.0 * m;
+    // hitPack.locy = 0.0 * m;
+    // hitPack.locz = 0.0 * m;
+    // hitPack.timestamp = 0.0 * ns;
+    // hitPack.edeposit = 0.0 * eV;
+    // hitPack.kepre = 0.0 * eV;
+    // hitPack.kepost = 0.0 * eV;
+    // hitPack.anglepre = 0.0 * deg;
     expPack.target_frequency = 0.0 * Hz;
     expPack.digi_sampling_rate = 0.0 * Hz;
   }

--- a/modules/FullAntennaSimReader.cpp
+++ b/modules/FullAntennaSimReader.cpp
@@ -95,25 +95,26 @@ DataPack FullAntennaSimReader::operator()()
     // check on hits, separately from trajectory reader
     // the hit reader may or may not hold data.
     if (reader2.GetEntries() > 0) { // if there is any hit at all, check with trajectory
-        while (reader2.Next()) { // get first entry, fill all data items
-            if (*hitevID == *eventID) { // only if this trajectory has a hit
-                dp.getHitRef().eventID   = *hitevID;
-                dp.getHitRef().trackID   = *hittrID;
-                dp.getHitRef().edeposit  = *edep * keV;
-                dp.getHitRef().timestamp = *tstamp * ns;
-                dp.getHitRef().kepre = *prek * keV;
-                dp.getHitRef().kepost = *postk * keV;
-                dp.getHitRef().anglepre = *preth * rad;
-                dp.getHitRef().anglepost = *postth * rad;
-                dp.getHitRef().locx = *locx * mm;
-                dp.getHitRef().locy = *locy * mm;
-                dp.getHitRef().locz = *locz * mm;
-                // store the filled hit_t
-                dp.hitsRef().push_back(dp.getHit());
-                std::cout << "found hit evt/track:  " << *hitevID << ", " << *hittrID << std::endl;
-            }
-        }
-        reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
+      while (reader2.Next()) { // get first entry, fill all data items
+	if (*hitevID == *eventID && *hittrID == *trackID) { // only if this trajectory has a hit
+	  hit_t myhit;
+	  myhit.eventID   = *hitevID;
+	  myhit.trackID   = *hittrID;
+	  myhit.edeposit  = *edep * keV;
+	  myhit.timestamp = *tstamp * ns;
+	  myhit.kepre = *prek * keV;
+	  myhit.kepost = *postk * keV;
+	  myhit.anglepre = *preth * rad;
+	  myhit.anglepost = *postth * rad;
+	  myhit.locx = *locx * mm;
+	  myhit.locy = *locy * mm;
+	  myhit.locz = *locz * mm;
+	  // store the filled hit_t
+	  dp.hitsRef().push_back(myhit);
+	  std::cout << "found hit evt/track:  " << myhit.eventID << ", " << myhit.trackID << std::endl;
+	}
+      }
+      reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
     }
     if (!stvec->empty()) { // book truth from trajectory
       dp.getTruthRef().start_time = stvec->front() * ns;

--- a/modules/FullKinematicsSimReader.cpp
+++ b/modules/FullKinematicsSimReader.cpp
@@ -103,26 +103,27 @@ DataPack FullKinematicsSimReader::operator()()
     // check on hits, separately from trajectory reader
     // the hit reader may or may not hold data.
     if (reader2.GetEntries() > 0) { // if there is any hit at all, check with trajectory
-        while (reader2.Next()) { // get first entry, fill all data items
-            if (*hitevID == *eventID) { // only if this trajectory has a hit
-                dp.getHitRef().eventID   = *hitevID;
-                dp.getHitRef().trackID   = *hittrID;
-                dp.getHitRef().edeposit  = *edep * keV;
-                dp.getHitRef().timestamp = *tstamp * ns;
-                dp.getHitRef().kepre = *prek * keV;
-                dp.getHitRef().kepost = *postk * keV;
-                dp.getHitRef().anglepre = *preth * rad;
-                dp.getHitRef().anglepost = *postth * rad;
-                dp.getHitRef().locx = *locx * mm;
-                dp.getHitRef().locy = *locy * mm;
-                dp.getHitRef().locz = *locz * mm;
-                // store the filled hit_t
-                dp.hitsRef().push_back(dp.getHit());
-                std::cout << "found hit evt/track:  " << *hitevID << ", " << *hittrID << std::endl;
-                std::cout << "found hit track at time:  " << *hittrID << ", " << *tstamp*ns << std::endl;
-            }
-        }
-        reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
+      while (reader2.Next()) { // get first entry, fill all data items
+	if (*hitevID == *eventID && *hittrID == *trackID) { // only if this trajectory has a hit
+	  hit_t myhit;
+	  myhit.eventID   = *hitevID;
+	  myhit.trackID   = *hittrID;
+	  myhit.edeposit  = *edep * keV;
+	  myhit.timestamp = *tstamp * ns;
+	  myhit.kepre = *prek * keV;
+	  myhit.kepost = *postk * keV;
+	  myhit.anglepre = *preth * rad;
+	  myhit.anglepost = *postth * rad;
+	  myhit.locx = *locx * mm;
+	  myhit.locy = *locy * mm;
+	  myhit.locz = *locz * mm;
+	  // store the filled hit_t
+	  dp.hitsRef().push_back(myhit);
+	  std::cout << "found hit evt/track:  " << myhit.eventID << ", " << myhit.trackID << std::endl;
+	  std::cout << "found hit track at time:  " << myhit.trackID << ", " << myhit.timestamp << std::endl;
+	}
+      }
+      reader2.Restart(); // for each trajectory, have to loop over hits, then reset hits reader.
     }
     if (!tvec->empty()) { // book truth from trajectory
       dp.getTruthRef().start_time = tvec->front() * ns;

--- a/modules/WfmReader.cpp
+++ b/modules/WfmReader.cpp
@@ -76,16 +76,17 @@ DataPack WfmReader::operator()()
     // the hit reader may or may not hold data.
     if (! hitevID->empty()) {
       for (unsigned int j=0;j<hitevID->size();++j) {
-	dp.getHitRef().eventID   = hitevID->at(j);
-	dp.getHitRef().trackID   = hittrID->at(j);
-	dp.getHitRef().edeposit  = hitedep->at(j) * eV;
-	dp.getHitRef().timestamp = hittime->at(j) * ns;
-	dp.getHitRef().anglepost = hitposttheta->at(j) * deg;
-	dp.getHitRef().locx = hitx->at(j) * m;
-	dp.getHitRef().locy = hity->at(j) * m;
-	dp.getHitRef().locz = hitz->at(j) * m;
+	hit_t myhit;
+	myhit.eventID   = hitevID->at(j);
+	myhit.trackID   = hittrID->at(j);
+	myhit.edeposit  = hitedep->at(j) * eV;
+	myhit.timestamp = hittime->at(j) * ns;
+	myhit.anglepost = hitposttheta->at(j) * deg;
+	myhit.locx = hitx->at(j) * m;
+	myhit.locy = hity->at(j) * m;
+	myhit.locz = hitz->at(j) * m;
 	// store the filled hit_t
-	dp.hitsRef().push_back(dp.getHit());
+	dp.hitsRef().push_back(myhit);
       }
     }
     dp.getTruthRef().tooShort = emptyFlag; // store input truth

--- a/src/trackMerger.cpp
+++ b/src/trackMerger.cpp
@@ -206,16 +206,17 @@ DataPack trackMerger::readRow()
   // the hit reader may or may not hold data.
   if (! hitevID->empty()) {
     for (unsigned int j=0;j<hitevID->size();++j) {
-      dp.getHitRef().eventID   = hitevID->at(j);
-      dp.getHitRef().trackID   = hittrID->at(j);
-      dp.getHitRef().edeposit  = hitedep->at(j) * eV;
-      dp.getHitRef().timestamp = hittime->at(j) * ns;
-      dp.getHitRef().anglepost = hitposttheta->at(j) * deg;
-      dp.getHitRef().locx = hitx->at(j) * m;
-      dp.getHitRef().locy = hity->at(j) * m;
-      dp.getHitRef().locz = hitz->at(j) * m;
+      hit_t myhit;
+      myhit.eventID   = hitevID->at(j);
+      myhit.trackID   = hittrID->at(j);
+      myhit.edeposit  = hitedep->at(j) * eV;
+      myhit.timestamp = hittime->at(j) * ns;
+      myhit.anglepost = hitposttheta->at(j) * deg;
+      myhit.locx = hitx->at(j) * m;
+      myhit.locy = hity->at(j) * m;
+      myhit.locz = hitz->at(j) * m;
       // store the filled hit_t
-      dp.hitsRef().push_back(dp.getHit());
+      dp.hitsRef().push_back(myhit);
     }
   }
   dp.getTruthRef().nantenna = *nantenna; // store input truth

--- a/utils/readHitDigifile.cpp
+++ b/utils/readHitDigifile.cpp
@@ -63,7 +63,6 @@ int main(int argc, char** argv)
 
     // bring some order to values
     std::vector<hit_t> hits;
-    hit_t hit;
     truth_t truth;
     vertex_t vertex;
     digitizer_t measured;
@@ -127,6 +126,7 @@ int main(int argc, char** argv)
       // hits
       hits.clear();
       for (int j=0;j<hitevID->size();++j) {
+	hit_t hit;
 	hit.event_ID = hitevID->at(j);
 	hit.track_ID = hittrID->at(j);
 	hit.locx_m  = hitx->at(j);

--- a/utils/readHitDigifile.py
+++ b/utils/readHitDigifile.py
@@ -53,7 +53,7 @@ def convert_to_data_dict(event):
     datadict = {}
     truth = truth_t()
     vertex = vertex_t()
-    hit = hit_t()
+
     measured = digitizer_t()
 
     # copy all data from event
@@ -76,6 +76,7 @@ def convert_to_data_dict(event):
     hits = []
     nhits = event.hit_eventID.size()  # is vector.size()
     for h in range(nhits):
+        hit = hit_t()
         hit.event_ID = event.hit_eventID[h]
         hit.track_ID = event.hit_trackID[h]
         hit.locx_m = event.hit_locx_m[h]


### PR DESCRIPTION
get storage and reading of hits from simulation correct. These are stored in separate TTree from the simulation and must be read separately from other results. Getting the order and link to all other data items right needed repair, as did the display after processing in the reconstruction.
This commit appears to get that all done (for the sim results currently available).